### PR TITLE
master=>staging ::: Backend-TR-38

### DIFF
--- a/FlexibleComputerLanguage/OTPParser.cpp
+++ b/FlexibleComputerLanguage/OTPParser.cpp
@@ -122,86 +122,90 @@ Node *OTPParser::OTPJSONToNodeTree(std::string otpsString)
         otpNode->SetLValue("otp");
         otpNode->SetRValue("otp");
         root->AppendNode(otpNode);
-        for(rapidjson::Value::ConstMemberIterator tp = itr->MemberBegin(); tp != itr->MemberEnd(); ++tp)
+        for(rapidjson::Value::ConstMemberIterator tps = itr->MemberBegin(); tps != itr->MemberEnd(); ++tps)
         {
-            rapidjson::Value &tpjson = (rapidjson::Value&)(itr->GetObject()[tp->name.GetString()]);
-            Node *tpnode = MemoryManager::Inst.CreateNode(++id);
-            Node *itemnode = MemoryManager::Inst.CreateNode(++id);
-            tpnode->SetValue((char *)tpjson["stageID"].GetString());
-            itemnode->SetRValue((char *)tpjson["item"]["itemID"].GetString());
-            itemnode->SetLValue((char *)tpjson["item"]["itemName"].GetString());
-            tpnode->SetCustomObj(itemnode);
-            otpNode->SetCustomObj(itemnode);
-            otpNode->AppendNode(tpnode);
-            for (rapidjson::Value::ConstValueIterator tdp = tpjson["traceabilityDataPackets"].Begin(); tdp != tpjson["traceabilityDataPackets"].End(); ++tdp)
+            rapidjson::Value &tpsArray = (rapidjson::Value&)(itr->GetObject()[tps->name.GetString()]);
+            for(rapidjson::Value::ConstValueIterator tp = tpsArray.Begin(); tp != tpsArray.End(); ++tp)
             {
-                rapidjson::Value &tdpjson = (rapidjson::Value&)(*tdp);
-                Node *tdpnode = MemoryManager::Inst.CreateNode(++id);
-                tdpnode->SetValue((char *)tdpjson["userID"].GetString());
-                tpnode->AppendNode(tdpnode);
-                for (rapidjson::Value::ConstValueIterator td = tdpjson["traceabilityData"].Begin(); td != tdpjson["traceabilityData"].End(); ++td)
+                rapidjson::Value &tpjson = (rapidjson::Value&)(*tp);
+                Node *tpnode = MemoryManager::Inst.CreateNode(++id);
+                Node *itemnode = MemoryManager::Inst.CreateNode(++id);
+                tpnode->SetValue((char *)tpjson["stageID"].GetString());
+                itemnode->SetRValue((char *)tpjson["item"]["itemID"].GetString());
+                itemnode->SetLValue((char *)tpjson["item"]["itemName"].GetString());
+                tpnode->SetCustomObj(itemnode);
+                otpNode->SetCustomObj(itemnode);
+                otpNode->AppendNode(tpnode);
+                for (rapidjson::Value::ConstValueIterator tdp = tpjson["traceabilityDataPackets"].Begin(); tdp != tpjson["traceabilityDataPackets"].End(); ++tdp)
                 {
-                    rapidjson::Value &tdjson = (rapidjson::Value&)(*td);
-                    Node *tdnode = MemoryManager::Inst.CreateNode(++id);
-                    tdpnode->AppendNode(tdnode);
-                    tdnode->SetValue((char *)tdjson["key"].GetString());
-                    //                tdnode->SetValue((char *)"something is better");
-                    if (tdjson["val"].IsObject() || tdjson["val"].IsArray())
+                    rapidjson::Value &tdpjson = (rapidjson::Value&)(*tdp);
+                    Node *tdpnode = MemoryManager::Inst.CreateNode(++id);
+                    tdpnode->SetValue((char *)tdpjson["userID"].GetString());
+                    tpnode->AppendNode(tdpnode);
+                    for (rapidjson::Value::ConstValueIterator td = tdpjson["traceabilityData"].Begin(); td != tdpjson["traceabilityData"].End(); ++td)
                     {
-                        rapidjson::Value &val = (rapidjson::Value &)tdjson["val"];
-                        createTDTree(val, tdnode);
-                    }
-                    else if (tdjson["val"].IsBool())
-                    {
-                        PString pStr = 0;
-                        MemoryManager::Inst.CreateObject(&pStr);
-                        bool val = tdjson["val"].GetBool();
-                        std::string val_bool = (val ? "true" : "false");
-                        pStr->SetValue(val ? "true" : "false");
-                        tdnode->SetEntityObj((PENTITY)pStr);
-                        tdnode->SetLValue((char *)val_bool.c_str());
-                    }
-                    else if (tdjson["val"].IsInt())
-                    {
-                        PString pStr = 0;
-                        MemoryManager::Inst.CreateObject(&pStr);
-                        int val = tdjson["val"].GetInt();
-                        pStr->SetValue(std::to_string(val));
-                        tdnode->SetEntityObj((PENTITY)pStr);
-                        tdnode->SetLValue((char *)std::to_string(val).c_str());
-                    }
-                    else if (tdjson["val"].IsFloat())
-                    {
-                        PString pStr = 0;
-                        MemoryManager::Inst.CreateObject(&pStr);
-                        float val = tdjson["val"].GetFloat();
-                        pStr->SetValue(std::to_string(val));
-                        tdnode->SetEntityObj((PENTITY)pStr);
-                        tdnode->SetLValue((char *)std::to_string(val).c_str());
-                    }
-                    else
-                    {
-                        PString pStr = 0;
-                        MemoryManager::Inst.CreateObject(&pStr);
-                        std::string val = tdjson["val"].GetString();
-                        //                    std::replace(val.begin(), val.end(), '"', '\0');
-                        val.erase(std::remove(val.begin(), val.end(), '"'), val.end());
-                        pStr->SetValue(tdjson["val"].GetString());
-                        tdnode->SetEntityObj((PENTITY)pStr);
-                        tdnode->SetLValue((char *)val.c_str());
-                        //                    std::cout << ((PENTITY)tdnode->GetEntityObj())->ul_Type;
+                        rapidjson::Value &tdjson = (rapidjson::Value&)(*td);
+                        Node *tdnode = MemoryManager::Inst.CreateNode(++id);
+                        tdpnode->AppendNode(tdnode);
+                        tdnode->SetValue((char *)tdjson["key"].GetString());
+                        //                tdnode->SetValue((char *)"something is better");
+                        if (tdjson["val"].IsObject() || tdjson["val"].IsArray())
+                        {
+                            rapidjson::Value &val = (rapidjson::Value &)tdjson["val"];
+                            createTDTree(val, tdnode);
+                        }
+                        else if (tdjson["val"].IsBool())
+                        {
+                            PString pStr = 0;
+                            MemoryManager::Inst.CreateObject(&pStr);
+                            bool val = tdjson["val"].GetBool();
+                            std::string val_bool = (val ? "true" : "false");
+                            pStr->SetValue(val ? "true" : "false");
+                            tdnode->SetEntityObj((PENTITY)pStr);
+                            tdnode->SetLValue((char *)val_bool.c_str());
+                        }
+                        else if (tdjson["val"].IsInt())
+                        {
+                            PString pStr = 0;
+                            MemoryManager::Inst.CreateObject(&pStr);
+                            int val = tdjson["val"].GetInt();
+                            pStr->SetValue(std::to_string(val));
+                            tdnode->SetEntityObj((PENTITY)pStr);
+                            tdnode->SetLValue((char *)std::to_string(val).c_str());
+                        }
+                        else if (tdjson["val"].IsFloat())
+                        {
+                            PString pStr = 0;
+                            MemoryManager::Inst.CreateObject(&pStr);
+                            float val = tdjson["val"].GetFloat();
+                            pStr->SetValue(std::to_string(val));
+                            tdnode->SetEntityObj((PENTITY)pStr);
+                            tdnode->SetLValue((char *)std::to_string(val).c_str());
+                        }
+                        else
+                        {
+                            PString pStr = 0;
+                            MemoryManager::Inst.CreateObject(&pStr);
+                            std::string val = tdjson["val"].GetString();
+                            //                    std::replace(val.begin(), val.end(), '"', '\0');
+                            val.erase(std::remove(val.begin(), val.end(), '"'), val.end());
+                            pStr->SetValue(tdjson["val"].GetString());
+                            tdnode->SetEntityObj((PENTITY)pStr);
+                            tdnode->SetLValue((char *)val.c_str());
+                            //                    std::cout << ((PENTITY)tdnode->GetEntityObj())->ul_Type;
 
-                        //                    tdnode->SetValue((char *)tdjson["val"].dump().c_str());
-                    }
-                    //                std::cout << (char *)std::to_string(tdjson["type"].get<int>()).c_str();
-//                std::cout << tdjson.HasMember("type");
-                    if (tdjson.HasMember("type"))
-                    {
-                        tdnode->SetRValue((char *)std::to_string(tdjson["type"].GetInt()).c_str());
-                    }
-                    else
-                    {
-                        tdnode->SetRValue("90");
+                            //                    tdnode->SetValue((char *)tdjson["val"].dump().c_str());
+                        }
+                        //                std::cout << (char *)std::to_string(tdjson["type"].get<int>()).c_str();
+    //                std::cout << tdjson.HasMember("type");
+                        if (tdjson.HasMember("type"))
+                        {
+                            tdnode->SetRValue((char *)std::to_string(tdjson["type"].GetInt()).c_str());
+                        }
+                        else
+                        {
+                            tdnode->SetRValue("90");
+                        }
                     }
                 }
             }

--- a/FlexibleComputerLanguage/OTPParser.cpp
+++ b/FlexibleComputerLanguage/OTPParser.cpp
@@ -140,13 +140,16 @@ Node *OTPParser::OTPJSONToNodeTree(std::string otpsString)
                 {
                     rapidjson::Value &tdpjson = (rapidjson::Value&)(*tdp);
                     Node *tdpnode = MemoryManager::Inst.CreateNode(++id);
+                    Node *tdpidnode = MemoryManager::Inst.CreateNode(++id);
                     tdpnode->SetValue((char *)tdpjson["userID"].GetString());
+                    tdpidnode->SetValue((char *)tdpjson["id"].GetString());
                     tpnode->AppendNode(tdpnode);
+                    tdpnode->AppendNode(tdpidnode);
                     for (rapidjson::Value::ConstValueIterator td = tdpjson["traceabilityData"].Begin(); td != tdpjson["traceabilityData"].End(); ++td)
                     {
                         rapidjson::Value &tdjson = (rapidjson::Value&)(*td);
                         Node *tdnode = MemoryManager::Inst.CreateNode(++id);
-                        tdpnode->AppendNode(tdnode);
+                        tdpidnode->AppendNode(tdnode);
                         tdnode->SetValue((char *)tdjson["key"].GetString());
                         //                tdnode->SetValue((char *)"something is better");
                         if (tdjson["val"].IsObject() || tdjson["val"].IsArray())


### PR DESCRIPTION
**Implements Backend-TR-38**
### Changes Proposed
- The OTP passed on to the Query Language has been changed to the Generic OTP over the Client OTP
-  Instead of one TP there are now an array of TPs in the OTP for each stage
- An additional for loop has been used in the OTP Parser to accommodate this

### Impact
- The TDP ID can now be extracted for the relevant traceability data item that has to be verified through blockchain
- The Generic OTP is now used for the QL over the Client OTP

### Other Information
Not applicable

Checklist
- [ ] Console logs deleted
- [ ] Lint issues are checked
- [ ] No commented code