### PR TITLE
master => staging - TR-47 - Threading infinite loop correction

### DIFF
--- a/FlexibleComputerLanguage/main.cpp
+++ b/FlexibleComputerLanguage/main.cpp
@@ -199,6 +199,10 @@ void *readSlave(void *fifosin)
             }
             pthread_mutex_unlock(&mutex_read);
         }
+        else
+        {
+            std::this_thread::sleep_for (std::chrono::milliseconds(10));
+        }
     }
 
     NamedPipeOperations::closeReadPipe(readStream, fdIn);
@@ -265,6 +269,10 @@ void *processSlave(void *)
 
             pthread_mutex_unlock(&mutex_write);
         }
+        else
+        {
+            std::this_thread::sleep_for (std::chrono::milliseconds(10));
+        }
     }
 }
 
@@ -291,6 +299,10 @@ void *writeSlave(void *fifosout)
             NamedPipeOperations::closeWritePipe(writeStream, fdOut);
             close(fdOut);
             LOG(INFO) << "request wrapped up";
+        }
+        else
+        {
+            std::this_thread::sleep_for (std::chrono::milliseconds(10));
         }
     }
 }


### PR DESCRIPTION
**Implements: Add Compute Endpoints | Backend-TR-47**
### Changes Proposed
- This will correct the infinite loop and put the thread to sleep for 10 milliseconds.

### Impact
- CPU usage which was jumping to beyond 100% will be fixed.

### Other Information
N/A

Checklist
- [x] Console logs deleted
- [ ] Lint issues are checked
- [ ] No commented code